### PR TITLE
removes author and date from vignettes

### DIFF
--- a/Rpath.Rproj
+++ b/Rpath.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: 34da8677-83fb-4804-a689-246d95211d65
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/vignettes/ModelSetup.Rmd
+++ b/vignettes/ModelSetup.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Set up a food web model"
-author: "Sean Lucey"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Set up a food web model}

--- a/vignettes/Rpath.Rmd
+++ b/vignettes/Rpath.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Rpath: an open source food web model"
-author: "Sean M. Lucey"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 csl: "ices-journal-of-marine-science.csl"
 bibliography: references.bib

--- a/vignettes/RunRpath.Rmd
+++ b/vignettes/RunRpath.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Create a static food web model in Rpath"
-author: "Vignette Author"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Create a static food web model in Rpath}

--- a/vignettes/RunRsim.Rmd
+++ b/vignettes/RunRsim.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Run a dynamic food web simulation in Rsim"
-author: "Sean M. Lucey"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Run a dynamic food web simulation in Rsim}

--- a/vignettes/ecosense.Rmd
+++ b/vignettes/ecosense.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Generating an Rsim ensemble with Ecosense"
-author: "George A. Whitehouse"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Generating an Rsim ensemble with Ecosense}


### PR DESCRIPTION
Removed author and date fields from yaml in vignette files, as per discussion at 9 April 2025 development meeting. 

Vignettes build locally without author or date fields.