### PR TITLE
fmort bugfix applied

### DIFF
--- a/src/ecosim.cpp
+++ b/src/ecosim.cpp
@@ -752,20 +752,20 @@ int sp, links, prey, pred, gr, egr, dest, isp, ist, ieco;
    for (sp=NUM_LIVING+1; sp<=NUM_LIVING+NUM_DEAD; sp++){
       MzeroLoss[sp] = 0.0;
    }
-    
-// Add mortality forcing
-   for (int i=1; i<=NUM_DEAD+NUM_LIVING; i++){
-     FoodLoss[i]  *= force_bymort(dd, i);
-     MzeroLoss[i] *= force_bymort(dd, i);
-   }
-   
-// Add migration forcing
-   MigrateLoss = clone(state_Biomass);
-   for (int i=1; i<=NUM_DEAD+NUM_LIVING; i++){
-     MigrateLoss[i]  *= force_bymigrate(dd, i);
-   }
 
-   
+// Bugfix 17-Jun-2025, commenting these out (moved to ~line624 above)    
+//// Add mortality forcing
+//   for (int i=1; i<=NUM_DEAD+NUM_LIVING; i++){
+//     FoodLoss[i]  *= force_bymort(dd, i);
+//     MzeroLoss[i] *= force_bymort(dd, i);
+//   }
+//   
+//// Add migration forcing
+//   MigrateLoss = clone(state_Biomass);
+//   for (int i=1; i<=NUM_DEAD+NUM_LIVING; i++){
+//     MigrateLoss[i]  *= force_bymigrate(dd, i);
+//   }
+
 // Sum up derivitive parts (vector sums)
 // Override for group 0 (considered "the sun", never changing)        
    TotGain = FoodGain + DetritalGain + FishingGain;      


### PR DESCRIPTION
<
# BEFORE FIX (DEV BRANCH)
library(Rpath)
bal <- rpath(REco.params)
scene_base <- rsim.scenario(bal,REco.params,years=c(1:10))
# Apply a forcemort anomaly of 1.1
  scene_test <- adjust.forcing(scene_base,"ForcedMort","Foragefish1", sim.year=1, value=1.1)

# Get rsim derivative for timestep 1
  deriv_base <- rsim.deriv(scene_base,sim.year=1)
  deriv_test <- rsim.deriv(scene_test,sim.year=1)

# Parts of derivative to look at for test (living groups only shown)
deriv_base[rpath.living(bal), c("TotGain","TotLoss","FoodLoss","MzeroLoss")]
#                     TotGain      TotLoss     FoodLoss    MzeroLoss
#Seabirds           1.1435750    1.1435750 0.000000e+00   0.00145020
#Whales             3.1671040   3.1671040 0.000000e+00   0.01407390
#Seals              0.8613750    0.8613750 0.000000e+00   0.00050000
#JuvRoundfish1      1.0974235    1.0974235 8.600087e-02   0.17525130
#AduRoundfish1      3.0441000    3.0441000 8.744286e-02   0.35135714
#JuvRoundfish2     13.4801481   13.4801481 8.904497e-02   2.49643248
#AduRoundfish2     20.9903400   20.9903400 2.040214e-01   1.76700364
#JuvFlatfish1       0.5595879    0.5595879 5.123829e-02   0.05158834
#AduFlatfish1       8.3030400    8.3030400 1.995084e-01   1.11965155
#JuvFlatfish2       0.5626651    0.5626651 5.123829e-02   0.05267936
#AduFlatfish2       1.2489100    1.2489100 4.328945e-02   0.01973055
#OtherGroundfish   13.0536000   13.0536000 3.970998e+00   0.08900162
#Foragefish1       17.9520000   17.9520000 2.727178e+00   0.03282250
#Foragefish2       26.5550000   26.5550000 2.920628e+00   0.04337213
#OtherForagefish   18.3600000   18.3600000 7.290634e+00   0.32836617
#Megabenthos       58.9799058   58.9799058 1.404108e+01   3.55776911
#Shellfish         36.4000000   36.4000000 5.675788e+00   2.91421175
#Macrobenthos     348.0000000  348.0000000 1.201634e+02   1.63648796
#Zooplankton     3588.0000000 3588.0000000 8.669279e+02  30.07205327
#Phytoplankton   2400.0000000 2400.0000000 2.176342e+03 223.65799754

deriv_test[rpath.living(bal), c("TotGain","TotLoss","FoodLoss","MzeroLoss")]/
deriv_base[rpath.living(bal), c("TotGain","TotLoss","FoodLoss","MzeroLoss")]

                TotGain  TotLoss FoodLoss MzeroLoss
Seabirds              1 1.000000      NaN      1.00
Whales                1 1.000000      NaN      1.00
Seals                 1 1.000000      NaN      1.00
JuvRoundfish1         1 1.000000     1.00      1.00
AduRoundfish1         1 1.000000     1.00      1.00
JuvRoundfish2         1 1.000000     1.00      1.00
AduRoundfish2         1 1.000000     1.00      1.00
JuvFlatfish1          1 1.000000     1.00      1.00
AduFlatfish1          1 1.000000     1.00      1.00
JuvFlatfish2          1 1.000000     1.00      1.00
AduFlatfish2          1 1.000000     1.00      1.00
OtherGroundfish       1 1.000000     1.00      1.00
Foragefish1           1 1.032286     1.21      1.21
Foragefish2           1 1.000000     1.00      1.00
OtherForagefish       1 1.000000     1.00      1.00
Megabenthos           1 1.000000     1.00      1.00
Shellfish             1 1.000000     1.00      1.00
Macrobenthos          1 1.000000     1.00      1.00
Zooplankton           1 1.000000     1.00      1.00
Phytoplankton         1 1.000000     1.00      1.00

# RESULT:  Increase is 1.21, which is 1.1 * 1.1.  (multiplication applied twice, the bug)

# AFTER FIX, SAME CODE ABOVE GIVES:

                TotGain  TotLoss FoodLoss MzeroLoss
Seabirds              1 1.000000      NaN       1.0
Whales                1 1.000000      NaN       1.0
Seals                 1 1.000000      NaN       1.0
JuvRoundfish1         1 1.000000      1.0       1.0
AduRoundfish1         1 1.000000      1.0       1.0
JuvRoundfish2         1 1.000000      1.0       1.0
AduRoundfish2         1 1.000000      1.0       1.0
JuvFlatfish1          1 1.000000      1.0       1.0
AduFlatfish1          1 1.000000      1.0       1.0
JuvFlatfish2          1 1.000000      1.0       1.0
AduFlatfish2          1 1.000000      1.0       1.0
OtherGroundfish       1 1.000000      1.0       1.0
Foragefish1           1 1.015374      1.1       1.1
Foragefish2           1 1.000000      1.0       1.0
OtherForagefish       1 1.000000      1.0       1.0
Megabenthos           1 1.000000      1.0       1.0
Shellfish             1 1.000000      1.0       1.0
Macrobenthos          1 1.000000      1.0       1.0
Zooplankton           1 1.000000      1.0       1.0
Phytoplankton         1 1.000000      1.0       1.0

# The correct values!
>