### PR TITLE
rsim step dyt fix

### DIFF
--- a/R/ecosim_multistep.R
+++ b/R/ecosim_multistep.R
@@ -58,5 +58,8 @@ rsim.step <- function(Rsim.scenario, Rsim.output, method = 'AB',year.end){
   full.run$annual_Qlink <- rbind(full.run$annual_Qlink, annual_Qlink)
   full.run$end_state <- next.run$end_state
   
+  # dyt continuity fix added 18-Jun-2025
+  full.run$dyt <- next.run$dyt
+  
   return(full.run)
 }


### PR DESCRIPTION
Rsim step function does not carry over dyt trajectory and gives different results than Rsim run with discontinuities on every restart.  Black line is rsim.run, red line is with yearly rsim.steps
![Step_test](https://github.com/user-attachments/assets/c2179832-def8-448c-924c-768aabdf04c9)
