### PR TITLE
fixed broken path to contributing md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Use this template to report bugs
-title: "[Bug Report]:"
-labels: "[bug]"
+title: "[Bug Report]: "
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -11,8 +11,7 @@ body:
         We will need this information to reproduce and fix any issues. Thanks
         
         We are also happy to accept contributions from our users. So if you have a solution to the
-        bug consider contributing. For more details see
-        [here](https://github.com/NOAA-EDAB/Rpath/CONTRIBUTING.md).
+        bug consider contributing. For more details see [here](https://github.com/NOAA-EDAB/Rpath/blob/main/CONTRIBUTING.md).
   - type: textarea
     id: bugdesc
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,8 +11,7 @@ body:
         the current issues to see if an issue [already exists](https://github.com/NOAA-EDAB/Rpath/issues?q=is%3Aissue%20state%3Aopen%20label%3Afeature)
         for your feature.
 
-        We are also happy to accept contributions from our users. For more details see
-        [here](https://github.com/NOAA-EDAB/Rpath/CONTRIBUTING.md).
+        We are also happy to accept contributions from our users. For more details see [here](https://github.com/NOAA-EDAB/Rpath/blob/main/CONTRIBUTING.md).
 
   - type: textarea
     attributes:


### PR DESCRIPTION
The paths in both issue templates are broken.
This fixes them and assigns the bug label automatically to any issue created as a bug